### PR TITLE
Fix missing closing brace

### DIFF
--- a/src/utils/financialCalculations.js
+++ b/src/utils/financialCalculations.js
@@ -499,3 +499,4 @@ export class PortfolioOptimizer {
       type: 'target_volatility'
     } : this.optimizeMaxSharpe(numSamples);
   }
+}


### PR DESCRIPTION
## Summary
- close `PortfolioOptimizer` class in financial calculations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de41283f0832f8b938f25cb395890