### PR TITLE
Enable dated real quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npx expo start
    ```
 
+### Using real market data
+
+By default the application generates realistic mock prices so it works
+offline. If you want the app to download the last year of daily prices
+directly from Yahoo Finance set the `USE_REAL_DATA` environment
+variable when starting Expo:
+
+```bash
+USE_REAL_DATA=true npx expo start
+```
+
+This pulls the most recent year of daily closing prices ending today so
+your analysis is always based on current market data. Fetching real
+data may require running behind a proxy server to avoid CORS issues on
+some platforms.
+
 In the output, you'll find options to open the app in a
 
 - [development build](https://docs.expo.dev/develop/development-builds/introduction/)

--- a/src/utils/dataFetcher.js
+++ b/src/utils/dataFetcher.js
@@ -3,8 +3,12 @@
 
 export class DataFetcher {
   constructor() {
-    // Yahoo Finance has CORS issues, so we'll use mock data primarily
-    this.useRealData = false; // Set to true if you have a backend proxy
+    // If USE_REAL_DATA env var is set the fetcher will try to load
+    // one year of daily quotes ending today from Yahoo Finance.
+    // Otherwise high quality mock data is generated. Real requests
+    // may require a proxy due to CORS restrictions when running in
+    // the browser.
+    this.useRealData = process.env.USE_REAL_DATA === 'true';
   }
 
   /**
@@ -55,9 +59,56 @@ export class DataFetcher {
    * Real Yahoo Finance data (only works with backend proxy)
    */
   async fetchRealYahooData(symbol, period = '1y') {
-    // This would need a backend proxy to avoid CORS
-    // For now, we'll use mock data
-    throw new Error('CORS restrictions - using mock data');
+    const now = Math.floor(Date.now() / 1000);
+    const seconds = this.getPeriodSecondsForApi(period);
+    const start = now - seconds;
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?period1=${start}&period2=${now}&interval=1d`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Yahoo request failed: ${response.status}`);
+    }
+    const json = await response.json();
+    const result = json?.chart?.result?.[0];
+    if (!result || !result.indicators?.quote?.[0]) {
+      throw new Error('Invalid data from Yahoo Finance');
+    }
+
+    const { timestamp } = result;
+    const quote = result.indicators.quote[0];
+    const data = [];
+    const returns = [];
+    let prevClose = null;
+    for (let i = 0; i < timestamp.length; i++) {
+      const price = quote.close[i];
+      if (price == null) continue;
+      const date = new Date(timestamp[i] * 1000);
+      data.push({
+        date,
+        open: quote.open[i],
+        high: quote.high[i],
+        low: quote.low[i],
+        close: price,
+        volume: quote.volume[i]
+      });
+      if (prevClose != null) {
+        returns.push({ date, return: (price - prevClose) / prevClose });
+      }
+      prevClose = price;
+    }
+
+    return {
+      symbol,
+      prices: data,
+      returns,
+      currentPrice: data[data.length - 1]?.close || 0,
+      metadata: {
+        start: data[0]?.date,
+        end: data[data.length - 1]?.date,
+        count: data.length,
+        isMock: false,
+        stockType: this.getStockParameters(symbol).type
+      }
+    };
   }
 
   /**
@@ -208,6 +259,22 @@ export class DataFetcher {
       '5y': 1260
     };
     return periods[period] || 252;
+  }
+
+  /**
+   * Convert a period string to seconds for Yahoo Finance API
+   */
+  getPeriodSecondsForApi(period) {
+    const daysMap = {
+      '1mo': 30,
+      '3mo': 90,
+      '6mo': 182,
+      '1y': 365,
+      '2y': 730,
+      '5y': 1825
+    };
+    const days = daysMap[period] || 365;
+    return days * 24 * 60 * 60;
   }
 
   /**


### PR DESCRIPTION
## Summary
- document that real data loads the last year of prices
- fetch real Yahoo data using explicit start and end dates

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de6cb8ca0832faf3a2b90a4f5f5eb