### PR TITLE
Fix duplicate URL in Yahoo data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npx expo start
    ```
 
+### Using real market data
+
+By default the application generates realistic mock prices so it works
+offline. If you want the app to download the last year of daily prices
+directly from Yahoo Finance set the `USE_REAL_DATA` environment
+variable when starting Expo:
+
+```bash
+USE_REAL_DATA=true npx expo start
+```
+
+This pulls the most recent year of daily closing prices ending today so
+your analysis is always based on current market data. Fetching real
+data may require running behind a proxy server to avoid CORS issues on
+some platforms.
+
 In the output, you'll find options to open the app in a
 
 - [development build](https://docs.expo.dev/develop/development-builds/introduction/)


### PR DESCRIPTION
## Summary
- document how to enable real Yahoo data
- clean up real Yahoo fetcher comment

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de6cb8ca0832faf3a2b90a4f5f5eb