### PR TITLE
Remove unused variable in VaR analysis

### DIFF
--- a/app/var.tsx
+++ b/app/var.tsx
@@ -175,7 +175,6 @@ export default function EnhancedVaRAnalyzer() {
       console.log(`📊 Analyzing ${minObservations} observations per asset`);
 
       // Step 3: Run VaR calculation based on method
-      let optimizationResult;
         console.log(`🎯 Running ${varMethod} optimization...`);
         
         switch (varMethod) {


### PR DESCRIPTION
## Summary
- clean up unused `optimizationResult` variable in `runAdvancedVaRAnalysis`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e04b8b744832fa98fe5ae0953967e