### PR TITLE
Fix JSX syntax errors in app

### DIFF
--- a/app/var.tsx
+++ b/app/var.tsx
@@ -747,6 +747,9 @@ export default function EnhancedVaRAnalyzer() {
                   );
                 })}
 
+              </View>
+              )}
+
               {activeTab === 'stress' && results.stressResults && results.stressResults.length > 0 && (
                 <View>
                   <Text style={styles.chartTitle}>Stress Test Results</Text>

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -382,7 +382,7 @@ export const CorrelationMatrixChart: React.FC<CorrelationMatrixChartProps> = ({
         <Text style={styles.legendTitle}>Correlation Strength</Text>
         <View style={styles.legendRow}>
           <View style={[styles.legendSquare, { backgroundColor: '#E74C3C' }]} />
-          <Text style={styles.legendLabel}>Strong Positive (>0.7)</Text>
+          <Text style={styles.legendLabel}>Strong Positive (&gt;0.7)</Text>
         </View>
         <View style={styles.legendRow}>
           <View style={[styles.legendSquare, { backgroundColor: '#F39C12' }]} />
@@ -424,7 +424,7 @@ export const CorrelationMatrixChart: React.FC<CorrelationMatrixChartProps> = ({
                 Average correlation: {avgCorrelation.toFixed(3)}
               </Text>
               <Text style={styles.insightText}>
-                High correlations (>0.7): {highCorrelations} pairs
+                High correlations (&gt;0.7): {highCorrelations} pairs
               </Text>
               <Text style={styles.insightText}>
                 Diversification benefit: {avgCorrelation < 0.3 ? 'High' : avgCorrelation < 0.7 ? 'Moderate' : 'Low'}


### PR DESCRIPTION
## Summary
- close unbalanced `<View>` in advanced VaR analyzer
- escape `>` characters in charts legend text

## Testing
- `npx tsc -p tsconfig.json` *(fails: File 'expo/tsconfig.base' not found)*
- `npx prettier -c app/var.tsx`
- `npx prettier -c src/components/Charts.tsx`


------
https://chatgpt.com/codex/tasks/task_e_684e02f222d0832fa7e0a8aff035767a