### PR TITLE
Implement mean–variance target optimizations

### DIFF
--- a/__tests__/optimizer.test.js
+++ b/__tests__/optimizer.test.js
@@ -1,0 +1,26 @@
+const { PortfolioOptimizer } = require('../src/utils/financialCalculations');
+
+describe('Target weight optimizations', () => {
+  const len = 260;
+  const asset1 = Array.from({ length: len }, (_, i) => 0.0005 + 0.0001 * Math.sin(i));
+  const asset2 = Array.from({ length: len }, (_, i) => 0.0008 + 0.00015 * Math.cos(i * 0.3));
+  const asset3 = Array.from({ length: len }, (_, i) => 0.0003 + 0.00005 * Math.sin(i * 1.3));
+
+  const optimizer = new PortfolioOptimizer([asset1, asset2, asset3], 0.01);
+
+  test('calculateTargetReturnWeights hits target return', () => {
+    const target = 0.15; // 15% annual return
+    const w = optimizer.calculateTargetReturnWeights(target);
+    const metrics = optimizer.calculatePortfolioMetrics(w);
+    expect(metrics.expectedReturn).toBeCloseTo(target, 2);
+    expect(optimizer.validateOptimizationResult(w).isValid).toBe(true);
+  });
+
+  test('calculateTargetVolatilityWeights hits target volatility', () => {
+    const target = 0.1; // 10% annual vol
+    const w = optimizer.calculateTargetVolatilityWeights(target);
+    const metrics = optimizer.calculatePortfolioMetrics(w);
+    expect(metrics.volatility).toBeCloseTo(target, 2);
+    expect(optimizer.validateOptimizationResult(w).isValid).toBe(true);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.js']
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "expo lint",
-    "reset-project": "node ./scripts/reset-project.js"
+    "reset-project": "node ./scripts/reset-project.js",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- implement mean–variance solver for target return/volatility
- add jest configuration and tests for new optimizations
- expose `npm test` script

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e33377784832fba513c1486bc3892