### PR TITLE
Fix victory-native compatibility with React 19

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,7 @@
 // app/_layout.tsx - ENHANCED WITH BEAUTIFUL DESIGN & ANIMATIONS
 // Modern tab layout with gradients, animations, and improved UX
+// Polyfills for web compatibility
+import '../src/polyfills';
 
 import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,9 @@
+import { findNodeHandle } from 'react-native';
+import * as ReactDOM from 'react-dom';
+
+// Polyfill for libraries that still use ReactDOM.findDOMNode
+if (typeof (ReactDOM as any).findDOMNode !== 'function') {
+  (ReactDOM as any).findDOMNode = findNodeHandle as any;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- polyfill `findDOMNode` for React Native Web
- include the polyfill in the main app layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e458022cc832fbb545bf118488b3e