### PR TITLE
Fix ReactDOM.findDOMNode error

### DIFF
--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -1,6 +1,7 @@
 // src/components/Charts.tsx - ENHANCED WITH BEAUTIFUL ANIMATIONS
 // Enhanced with beautiful animations, better interactions, and modern design
 
+import '../polyfills';
 import React, { useRef, useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions, Animated, TouchableOpacity } from 'react-native';
 import { VictoryChart, VictoryScatter, VictoryPie, VictoryArea, VictoryAxis, 


### PR DESCRIPTION
## Summary
- import polyfills before victory components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e48e204e4832fa1a9a6d24cd7e036