### PR TITLE
Add constraints to PortfolioOptimizer

### DIFF
--- a/app/portfolio.tsx
+++ b/app/portfolio.tsx
@@ -259,7 +259,10 @@ export default function BeautifulPortfolioOptimizer() {
       // Step 5: Run optimization
       setOptimizationProgress(80);
       animateProgress(0.8);
-      const optimizer = new PortfolioOptimizer(returnsMatrix, riskFreeRate);
+      const optimizer = new PortfolioOptimizer(returnsMatrix, riskFreeRate, {
+        allowShortSelling,
+        maxPositionSize,
+      });
       
       let optimizationResult;
       console.log(`🎯 Running ${optimizationMethod} optimization with ${monteCarloSimulations.toLocaleString()} simulations...`);

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -1,6 +1,7 @@
 // src/components/Charts.tsx - ENHANCED WITH BEAUTIFUL ANIMATIONS
 // Enhanced with beautiful animations, better interactions, and modern design
 
+import '../polyfills';
 import React, { useRef, useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions, Animated, TouchableOpacity } from 'react-native';
 import { VictoryChart, VictoryScatter, VictoryPie, VictoryArea, VictoryAxis, 

--- a/src/utils/financialCalculations.js
+++ b/src/utils/financialCalculations.js
@@ -677,11 +677,14 @@ export class VaRCalculator {
  * FIXED Portfolio Optimizer without mathjs dependency
  */
 export class PortfolioOptimizer {
-  constructor(returnsMatrix, riskFreeRate = 0.02) {
+  constructor(returnsMatrix, riskFreeRate = 0.02, options = {}) {
     this.returnsMatrix = returnsMatrix;
     this.riskFreeRate = riskFreeRate;
     this.numAssets = returnsMatrix.length;
     this.numObservations = returnsMatrix[0].length;
+
+    this.allowShortSelling = options.allowShortSelling || false;
+    this.maxPositionSize = options.maxPositionSize || 1.0;
     
     this.meanReturns = this.calculateMeanReturns();
     this.covarianceMatrix = this.calculateCovarianceMatrix();
@@ -955,9 +958,16 @@ export class PortfolioOptimizer {
   }
 
   generateRandomWeights() {
-    const weights = Array.from({ length: this.numAssets }, () => Math.random());
-    const sum = weights.reduce((acc, weight) => acc + weight, 0);
-    return weights.map(weight => weight / sum);
+    let weights = [];
+    do {
+      weights = Array.from({ length: this.numAssets }, () => {
+        const r = Math.random();
+        return this.allowShortSelling ? r * 2 - 1 : r;
+      });
+      const sum = weights.reduce((acc, weight) => acc + weight, 0);
+      weights = weights.map(w => w / sum);
+    } while (weights.some(w => Math.abs(w) > this.maxPositionSize));
+    return weights;
   }
 
   calculateCapitalAllocation(targetReturn = null, targetVolatility = null) {
@@ -1057,16 +1067,29 @@ export class PortfolioOptimizer {
     const weightSum = weights.reduce((sum, w) => sum + w, 0);
     const hasNaN = weights.some(w => isNaN(w) || !isFinite(w));
     const hasNegative = weights.some(w => w < -tolerance);
+    const hasExcessive = weights.some(w => Math.abs(w) > this.maxPositionSize + tolerance);
 
     return {
-      isValid: !hasNaN && Math.abs(weightSum - 1.0) < tolerance && !hasNegative,
+      isValid:
+        !hasNaN &&
+        Math.abs(weightSum - 1.0) < tolerance &&
+        (this.allowShortSelling || !hasNegative) &&
+        !hasExcessive,
       weightSum,
       hasNaN,
       hasNegative,
+      hasExcessive,
       issues: [
         ...(hasNaN ? ['Contains NaN or infinite values'] : []),
-        ...(Math.abs(weightSum - 1.0) >= tolerance ? [`Weights sum to ${weightSum.toFixed(6)}, not 1.0`] : []),
-        ...(hasNegative ? ['Contains negative weights (short selling not allowed)'] : [])
+        ...(Math.abs(weightSum - 1.0) >= tolerance
+          ? [`Weights sum to ${weightSum.toFixed(6)}, not 1.0`]
+          : []),
+        ...(!this.allowShortSelling && hasNegative
+          ? ['Contains negative weights (short selling not allowed)']
+          : []),
+        ...(hasExcessive
+          ? [`Weight exceeds maximum position size (${this.maxPositionSize})`]
+          : [])
       ]
     };
   }


### PR DESCRIPTION
## Summary
- add optional short selling & position constraints to PortfolioOptimizer
- pass options from portfolio screen
- include a simple Jest config

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e48e204e4832fa1a9a6d24cd7e036