### PR TITLE
Add Jest to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "jest": "^29.7.0"
   },
   "private": true,
   "keywords": [


### PR DESCRIPTION
## Summary
- add Jest dev dependency in `package.json`

## Testing
- `npm install` *(fails: 403 Forbidden when fetching from npm registry)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4d09a028832f9b31d2724475818d