### PR TITLE
Fix correlation matrix props

### DIFF
--- a/app/portfolio.tsx
+++ b/app/portfolio.tsx
@@ -988,7 +988,10 @@ export default function BeautifulPortfolioOptimizer() {
                 />
               )}
 
-              {activeTab === 'correlation' && (
+              {activeTab === 'correlation' &&
+                results.correlationMatrix &&
+                results.tickers &&
+                results.correlationMatrix.length > 0 && (
                 <CorrelationMatrixChart
                   correlationMatrix={results.correlationMatrix}
                   tickers={results.tickers}

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -310,9 +310,9 @@ export const CAPMAnalysisChart: React.FC<CAPMAnalysisProps> = ({
 };
 
 // FIXED: Correlation Matrix Chart
-export const CorrelationMatrixChart: React.FC<CorrelationMatrixProps> = ({ 
-  correlationMatrix, 
-  tickers 
+export const CorrelationMatrixChart: React.FC<Partial<CorrelationMatrixProps>> = ({
+  correlationMatrix = [],
+  tickers = []
 }) => {
   if (!correlationMatrix || !tickers || correlationMatrix.length === 0) {
     return (
@@ -346,19 +346,19 @@ export const CorrelationMatrixChart: React.FC<CorrelationMatrixProps> = ({
           <View style={styles.correlationMatrix}>
             <View style={styles.correlationHeader}>
               <View style={styles.correlationCell} />
-              {tickers.map(ticker => (
+              {tickers?.map(ticker => (
                 <View key={ticker} style={styles.correlationCell}>
                   <Text style={styles.correlationHeaderText}>{ticker}</Text>
                 </View>
               ))}
             </View>
             
-            {correlationMatrix.map((row, i) => (
+            {correlationMatrix?.map((row, i) => (
               <View key={i} style={styles.correlationRow}>
                 <View style={styles.correlationCell}>
                   <Text style={styles.correlationHeaderText}>{tickers[i]}</Text>
                 </View>
-                {row.map((correlation, j) => (
+                {row?.map((correlation, j) => (
                   <View key={j} style={[
                     styles.correlationCell,
                     { backgroundColor: getCorrelationColor(correlation) + '20' }


### PR DESCRIPTION
## Summary
- guard correlation matrix chart from undefined props
- skip rendering correlation chart when data missing

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee0b4dadc832f8439c91d9a209adf