### PR TITLE
Fix correlation matrix retrieval

### DIFF
--- a/app/portfolio.tsx
+++ b/app/portfolio.tsx
@@ -403,14 +403,9 @@ export default function BeautifulPortfolioOptimizer() {
       }
 
       // Correlation matrix
-      const correlationMatrix = CorrelationCalculator.calculateCorrelationMatrix(returnsMatrix);
-      const correlationArray = [];
-      for (let i = 0; i < stockData.symbols.length; i++) {
-        correlationArray[i] = [];
-        for (let j = 0; j < stockData.symbols.length; j++) {
-          correlationArray[i][j] = correlationMatrix.get([i, j]);
-        }
-      }
+      const correlationMatrix = CorrelationCalculator.calculateCorrelationMatrix(
+        returnsMatrix
+      );
 
       // Risk attribution
       const riskAttribution = RiskAttributionCalculator.calculateRiskContribution(
@@ -449,7 +444,7 @@ export default function BeautifulPortfolioOptimizer() {
         capmReturns: capmResults,
         betas: betas,
         alphas: alphas,
-        correlationMatrix: correlationArray,
+        correlationMatrix: correlationMatrix,
         efficientFrontier: efficientFrontier,
         riskAttribution: riskAttribution,
         allSimulations: optimizationResult.allSimulations || [],

--- a/src/utils/financialCalculations.ts
+++ b/src/utils/financialCalculations.ts
@@ -573,22 +573,27 @@ export class RiskAttributionCalculator {
 
 // FIXED: Correlation Calculator
 export class CorrelationCalculator {
-  static calculateCorrelationMatrix(returnsMatrix: number[][]): Map<any, number> {
+  static calculateCorrelationMatrix(returnsMatrix: number[][]): number[][] {
     const n = returnsMatrix.length;
-    const correlationMap = new Map();
-    
+    const correlationMatrix: number[][] = Array.from({ length: n }, () =>
+      Array(n).fill(0)
+    );
+
     for (let i = 0; i < n; i++) {
       for (let j = 0; j < n; j++) {
         if (i === j) {
-          correlationMap.set([i, j], 1.0);
+          correlationMatrix[i][j] = 1.0;
         } else {
-          const corr = this.calculateCorrelation(returnsMatrix[i], returnsMatrix[j]);
-          correlationMap.set([i, j], corr);
+          const corr = this.calculateCorrelation(
+            returnsMatrix[i],
+            returnsMatrix[j]
+          );
+          correlationMatrix[i][j] = corr;
         }
       }
     }
-    
-    return correlationMap;
+
+    return correlationMatrix;
   }
   
   private static calculateCorrelation(arr1: number[], arr2: number[]): number {

--- a/tests/financialCalculations.test.js
+++ b/tests/financialCalculations.test.js
@@ -1,6 +1,8 @@
-import { VaRCalculator, PortfolioOptimizer } from '../src/utils/financialCalculations.js';
-
-import { VaRCalculator, PortfolioOptimizer } from '../src/utils/financialCalculations.js';
+import {
+  VaRCalculator,
+  PortfolioOptimizer,
+  CorrelationCalculator
+} from '../src/utils/financialCalculations.js';
 
 describe('VaRCalculator - Edge Cases and Fixes', () => {
   // Test data generators
@@ -172,6 +174,20 @@ describe('VaRCalculator - Edge Cases and Fixes', () => {
       expect(cleaned.length).toBe(identicalData.length);
       expect(cleaned.every(x => x === 0.01)).toBe(true);
     });
+  });
+});
+
+describe('CorrelationCalculator', () => {
+  test('returns accessible 2D array', () => {
+    const r1 = [0.01, -0.02, 0.03];
+    const r2 = [0.02, -0.01, 0.04];
+    const matrix = CorrelationCalculator.calculateCorrelationMatrix([r1, r2]);
+
+    expect(Array.isArray(matrix)).toBe(true);
+    expect(matrix.length).toBe(2);
+    expect(matrix[0].length).toBe(2);
+    expect(matrix[0][0]).toBeCloseTo(1, 5);
+    expect(matrix[0][1]).toBeCloseTo(matrix[1][0], 5);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix correlation matrix calculation to use 2D arrays
- simplify correlation matrix handling in portfolio optimization
- add regression test for `CorrelationCalculator`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee068c664832fbec3e6c52d8fd398