### PR TITLE
Add risk-free allocation option

### DIFF
--- a/app/portfolio.tsx
+++ b/app/portfolio.tsx
@@ -327,7 +327,7 @@ export default function FixedPortfolioOptimizer() {
       // Step 5: FIXED - Run optimization with proper target handling
       setOptimizationProgress(80);
       animateProgress(0.8);
-      const optimizer = new PortfolioOptimizer(returnsMatrix, riskFreeRate);
+      const optimizer = new PortfolioOptimizer(returnsMatrix, riskFreeRate, includeRiskFree);
     
       let optimizationResult;
       console.log(`🎯 Running ${optimizationMethod} optimization with ${monteCarloSimulations.toLocaleString()} simulations...`);

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -87,7 +87,9 @@ export const PortfolioWeightsChart: React.FC<PortfolioWeightsProps> = ({
     );
   }
 
-  // Ensure weights and tickers have same length
+  const includeRiskFree = weights.length === tickers.length + 1;
+
+  // Ensure weights and tickers have same length for risky assets
   const minLength = Math.min(weights.length, tickers.length);
   const validWeights = weights.slice(0, minLength);
   const validTickers = tickers.slice(0, minLength);
@@ -100,11 +102,21 @@ export const PortfolioWeightsChart: React.FC<PortfolioWeightsProps> = ({
 
   const pieData = validTickers.map((ticker, index) => ({
     name: ticker,
-    population: Math.round(validWeights[index] * 100 * 100) / 100, // Round to 2 decimals
+    population: Math.round(validWeights[index] * 100 * 100) / 100,
     color: colors[index % colors.length],
     legendFontColor: '#34495e',
     legendFontSize: 12,
   }));
+
+  if (includeRiskFree) {
+    pieData.push({
+      name: 'Risk-Free',
+      population: Math.round(weights[weights.length - 1] * 100 * 100) / 100,
+      color: '#95a5a6',
+      legendFontColor: '#34495e',
+      legendFontSize: 12,
+    });
+  }
 
   return (
     <View style={styles.chartContainer}>

--- a/tests/financialCalculations.test.js
+++ b/tests/financialCalculations.test.js
@@ -337,9 +337,43 @@ describe('Integration Tests', () => {
     expect(minRisk.volatility).toBeLessThanOrEqual(equalWeight.volatility);
     
     // Equal weight should have equal weights
-    equalWeight.weights.forEach(weight => {
-      expect(weight).toBeCloseTo(1/3, 2);
-    });
+  equalWeight.weights.forEach(weight => {
+    expect(weight).toBeCloseTo(1/3, 2);
+  });
+  });
+});
+
+describe('Include Risk-Free Flag', () => {
+  test('optimizer returns risk-free weight when flag is true', () => {
+    const mockReturns = [
+      generateNormalReturns(100),
+      generateNormalReturns(100),
+    ];
+
+    const optimizer = new PortfolioOptimizer(mockReturns, 0.02, true);
+    const resultReturn = optimizer.optimizeForTargetReturn(0.1);
+    const resultVol = optimizer.optimizeForTargetVolatility(0.15);
+
+    expect(resultReturn.weights.length).toBe(3);
+    expect(resultVol.weights.length).toBe(3);
+    expect(resultReturn.riskFreeWeight).toBeDefined();
+    expect(resultVol.riskFreeWeight).toBeDefined();
+  });
+
+  test('optimizer omits risk-free weight when flag is false', () => {
+    const mockReturns = [
+      generateNormalReturns(100),
+      generateNormalReturns(100),
+    ];
+
+    const optimizer = new PortfolioOptimizer(mockReturns, 0.02, false);
+    const resultReturn = optimizer.optimizeForTargetReturn(0.1);
+    const resultVol = optimizer.optimizeForTargetVolatility(0.15);
+
+    expect(resultReturn.weights.length).toBe(2);
+    expect(resultVol.weights.length).toBe(2);
+    expect(resultReturn.riskFreeWeight).toBeUndefined();
+    expect(resultVol.riskFreeWeight).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- extend `PortfolioOptimizer` to optionally include risk-free weight
- surface risk-free allocation from target optimizations
- pass risk-free flag from portfolio page
- show risk-free slice in weights chart
- test optimizer behavior with risk-free flag

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad03abac832fb903858c23521680