### PR TITLE
Improve Monte Carlo VaR

### DIFF
--- a/app/var.tsx
+++ b/app/var.tsx
@@ -470,15 +470,15 @@ export default function CompleteVaRAnalyzer() {
         );
       } else if (method === 'monte_carlo') {
         const portfolioReturns = VaRCalculator.calculatePortfolioReturns(returnsMatrix, weights);
-        const varValue = await VaRCalculator.calculateMonteCarloVaR(
+        const mcResult = VaRCalculator.calculateMonteCarloVaR(
           portfolioReturns,
           confidenceLevel,
           positionSize
         );
-        
+
         portfolioResult = {
-          var: varValue,
-          expectedShortfall: varValue * 1.5,
+          var: mcResult.var,
+          expectedShortfall: mcResult.expectedShortfall,
           method: 'monte_carlo',
           portfolioMean: 0,
           portfolioVolatility: 0,

--- a/tests/financialCalculations.test.js
+++ b/tests/financialCalculations.test.js
@@ -301,17 +301,28 @@ describe('Integration Tests', () => {
     expect(parametricResult.expectedShortfall).toBeGreaterThan(parametricResult.var);
     
     // Test historical VaR
-    const historicalResult = VaRCalculator.calculatePortfolioHistoricalVaR(
+  const historicalResult = VaRCalculator.calculatePortfolioHistoricalVaR(
       mockReturns, weights, 0.95, 1000000
-    );
+  );
     
     expect(historicalResult.var).toBeGreaterThan(0);
     expect(historicalResult.expectedShortfall).toBeGreaterThan(historicalResult.var);
     
     // VaR methods should give similar results for normal data
-    const ratio = parametricResult.var / historicalResult.var;
-    expect(ratio).toBeGreaterThan(0.5);
-    expect(ratio).toBeLessThan(2.0);
+  const ratio = parametricResult.var / historicalResult.var;
+  expect(ratio).toBeGreaterThan(0.5);
+  expect(ratio).toBeLessThan(2.0);
+
+  // Test Monte Carlo VaR
+  const mcResult = VaRCalculator.calculateMonteCarloVaR(
+    VaRCalculator.calculatePortfolioReturns(mockReturns, weights),
+    0.95,
+    1000000,
+    5000
+  );
+
+  expect(mcResult.var).toBeGreaterThan(0);
+  expect(mcResult.expectedShortfall).toBeGreaterThan(mcResult.var);
   });
 
   test('complete portfolio optimization workflow', () => {


### PR DESCRIPTION
## Summary
- extend Monte Carlo VaR to return a full `VaRResult`
- integrate new result structure in portfolio screen
- add test coverage for Monte Carlo VaR

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b1d646f4832fb95e255969b556d3