### PR TITLE
Fix Monte Carlo VaR simulation parameter

### DIFF
--- a/app/var.tsx
+++ b/app/var.tsx
@@ -473,7 +473,8 @@ export default function CompleteVaRAnalyzer() {
         const mcResult = VaRCalculator.calculateMonteCarloVaR(
           portfolioReturns,
           confidenceLevel,
-          positionSize
+          positionSize,
+          numSimulations
         );
 
         portfolioResult = {


### PR DESCRIPTION
## Summary
- pass `numSimulations` to `calculateMonteCarloVaR`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6850b6409db8832f8b3488050979bcaf