### PR TITLE
Add data check to Monte Carlo VaR

### DIFF
--- a/src/utils/financialCalculations.ts
+++ b/src/utils/financialCalculations.ts
@@ -1250,6 +1250,9 @@ export class VaRCalculator {
       if (!returns.length) {
         throw new Error('No returns provided');
       }
+      if (returns.length < 2) {
+        throw new Error('At least two returns are required for Monte Carlo VaR');
+      }
 
       const mean = returns.reduce((sum: number, x: number) => sum + x, 0) / returns.length;
       const volatility = Math.sqrt(

--- a/tests/financialCalculations.test.js
+++ b/tests/financialCalculations.test.js
@@ -175,6 +175,14 @@ describe('VaRCalculator - Edge Cases and Fixes', () => {
       expect(cleaned.every(x => x === 0.01)).toBe(true);
     });
   });
+
+  describe('Monte Carlo VaR', () => {
+    test('throws error with insufficient returns', () => {
+      expect(() => {
+        VaRCalculator.calculateMonteCarloVaR([0.01], 0.95, 1000);
+      }).toThrow('At least two returns are required for Monte Carlo VaR');
+    });
+  });
 });
 
 describe('CorrelationCalculator', () => {


### PR DESCRIPTION
## Summary
- validate input size in `calculateMonteCarloVaR`
- test error handling when only one return is supplied

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: ESLint require not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850b63ee088832f86583e4147ed0cb2