### PR TITLE
Fix Monte Carlo string casing

### DIFF
--- a/src/utils/financialCalculations.ts
+++ b/src/utils/financialCalculations.ts
@@ -1280,7 +1280,7 @@ export class VaRCalculator {
         var: varValue,
         expectedShortfall,
         confidenceLevel,
-        method: 'Monte Carlo'
+        method: 'monte_carlo'
       };
     } catch (error: unknown) {
       if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- return Monte Carlo method string as `monte_carlo`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba6b484c832fa04ab7b108dee793